### PR TITLE
Add simple HTTP service for testing the library end to end

### DIFF
--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -1,0 +1,131 @@
+# Licensed to the Tomaz Muraus under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Simple HTTP server which allows users to retrieve and store arbitrary Protobuf objects inside Cloud
+Datastore.
+"""
+
+import importlib
+
+from flask import Flask
+from flask import request
+from flask import jsonify
+
+from google.protobuf import json_format
+from google.cloud import datastore
+
+from src.translator import model_pb_to_entity_pb
+from src.translator import entity_pb_to_model_pb
+
+app = Flask(__name__)
+
+
+@app.route('/datastore/put/<key>', methods=['POST'])
+def put_db_object(key):
+    # type: (str) -> str
+    """
+    Store arbitrary Protobuf object in Google Datastore.
+
+    NOTE: Request body needs to contain Protobuf model serialized as JSON.
+    """
+    body = request.get_json()
+
+    # Fully qualified model name, e.g. "tests.generated.example_pb2.ExampleDBModel"
+    # NOTE: This module needs to be available in PYTHONPATH
+    model_name = body['model_name']
+    model_data = body['json_string']
+
+    # 1. Parse the JSON serialized data into native Protobuf object
+    split = model_name.rsplit('.', 1)
+
+    if len(split) != 2:
+        raise ValueError('Invalid module name: %s' % (model_name))
+
+    module_path, class_name = split
+
+    try:
+        module = importlib.import_module(module_path)
+        model_class = getattr(module, class_name, None)
+    except Exception as e:
+        raise ValueError('Class "%s" not found: %s' % (model_name), str(e))
+
+    if not model_class:
+        raise ValueError('Class "%s" not found' % (model_name))
+
+    model_pb = json_format.Parse(model_data, model_class())
+
+    # 2. Convert it into entity object
+    entity_pb = model_pb_to_entity_pb(model_pb)
+
+    client = datastore.Client()
+
+    # Set PK on the object
+    key_pb = client.key(model_pb.DESCRIPTOR.name, key).to_protobuf()
+    entity_pb.key.CopyFrom(key_pb)  # pylint: disable=no-member
+
+    # Set key on the object
+
+    # 3. Store it inside datastore
+    entity = datastore.helpers.entity_from_protobuf(entity_pb)
+    client.put(entity)
+    return ''
+
+
+@app.route('/datastore/get/<key>')
+def get_db_object(key):
+    # type: (str) -> tuple
+    """
+    Retrieve object from Google Datastore, serialize it into native object type and serialize it
+    as JSON.
+    """
+    model_name = request.args.get('model_name', '')
+    split = model_name.rsplit('.', 1)
+
+    if len(split) != 2:
+        raise ValueError('Invalid module name: %s' % (model_name))
+
+    module_path, class_name = split
+
+    try:
+        module = importlib.import_module(module_path)
+        model_class = getattr(module, class_name, None)
+    except Exception as e:
+        raise ValueError('Class "%s" not found: %s' % (model_name, str(e)))
+
+    if not model_class:
+        raise ValueError('Class "%s" not found' % (model_name))
+
+    # 1. Retrieve Entity from datastore
+    client = datastore.Client()
+
+    key = client.key(class_name, key)
+    entity = client.get(key)
+
+    # 2. Translate it to custom Protobuf object
+    entity_pb = datastore.helpers.entity_to_protobuf(entity)
+
+    model_pb = entity_pb_to_model_pb(model_pb_module=module, model_pb_class=model_class,
+                                     entity_pb=entity_pb)
+
+    # 3. Serialize it to JSON
+    model_pb_json = json_format.MessageToJson(model_pb)
+
+    result = jsonify({
+        'model_name': model_name,
+        'json_string': model_pb_json
+    })
+
+    return result, 200, {'Content-Type': 'application/json'}

--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -25,6 +25,7 @@ $ gunicorn examples/http_api.py:app
 import importlib
 from typing import Type
 from typing import Tuple
+from typing import Dict
 from types import ModuleType
 
 from flask import Flask
@@ -43,7 +44,7 @@ app = Flask(__name__)
 
 @app.route('/datastore/put/<key>', methods=['POST'])
 def put_db_object(key):
-    # type: (str) -> str
+    # type: (str) -> Tuple[str, int, Dict[str, str]]
     """
     Store arbitrary Protobuf object in Google Datastore.
 
@@ -69,17 +70,15 @@ def put_db_object(key):
     key_pb = client.key(model_pb.DESCRIPTOR.name, key).to_protobuf()
     entity_pb.key.CopyFrom(key_pb)  # pylint: disable=no-member
 
-    # Set key on the object
-
     # 3. Store it inside datastore
     entity = datastore.helpers.entity_from_protobuf(entity_pb)
     client.put(entity)
-    return ''
+    return '', 200, {}
 
 
 @app.route('/datastore/get/<key>')
 def get_db_object(key):
-    # type: (str) -> tuple
+    # type: (str) -> Tuple[str, int, Dict[str, str]]
     """
     Retrieve object from Google Datastore, serialize it into native object type and serialize it
     as JSON.

--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -16,6 +16,10 @@
 """
 Simple HTTP server which allows users to retrieve and store arbitrary Protobuf objects inside Cloud
 Datastore.
+
+To run it:
+
+$ gunicorn examples/http_api.py:app
 """
 
 import importlib

--- a/examples/http_api.py
+++ b/examples/http_api.py
@@ -31,7 +31,6 @@ from flask import Flask
 from flask import request
 from flask import jsonify
 
-from google.protobuf import message
 from google.protobuf import json_format
 from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
 from google.cloud import datastore

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,0 +1,2 @@
+flask
+gunicorn

--- a/src/translator.py
+++ b/src/translator.py
@@ -82,6 +82,9 @@ def model_pb_to_entity_pb(model_pb, exclude_falsy_values=False):
                                  the same as a default value (e.g. 0 for an integer field) and
                                  user not providing a value and default value being used instead.
     """
+    if not isinstance(model_pb, message.Message):
+        raise ValueError('model_pb argument is not a valid Protobuf class instance')
+
     fields = list(iter(model_pb.DESCRIPTOR.fields))
     fields = [field for field in fields if field not in ['key']]
 

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -251,6 +251,30 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         self.assertEqual(entity_pb_translated.properties['string_key'].string_value, 'value')
         self.assertEqual(entity_pb_translated.properties['int32_key'].integer_value, 100)
 
+    def test_model_pb_to_entity_pb_invalid_argument_type(self):
+        # type: () -> None
+        class Invalid(object):
+            pass
+
+        example_pb = Invalid()
+
+        expected_msg = 'model_pb argument is not a valid Protobuf class instance'
+        self.assertRaisesRegexp(ValueError, expected_msg, model_pb_to_entity_pb,
+                                example_pb)  # type: ignore
+
+    def test_model_pb_with_key_to_entity_pb_invalid_argument_type(self):
+        # type: () -> None
+        class Invalid(object):
+            pass
+
+        client = datastore.Client(credentials=EmulatorCreds(), _http=requests.Session(),
+                                  namespace='namespace1', project='project1')
+        example_pb = Invalid()
+
+        expected_msg = 'model_pb argument is not a valid Protobuf class instance'
+        self.assertRaisesRegexp(ValueError, expected_msg, model_pb_with_key_to_entity_pb, client,
+                                example_pb)
+
     def assertEntityPbHasPopulatedField(self, entity_pb, field_name):
         # type: (entity_pb2.Entity, str) -> None
         """

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,13 @@ commands =
 
 [testenv:lint]
 deps = -r requirements-test.txt
+       -r requirements-examples.txt
        -r requirements.txt
        mypy
        mypy-protobuf
 commands =
-    flake8 --config ./lint-configs/.flake8 src/ tests/
-    pylint -E --rcfile=./lint-configs/.pylintrc src/ tests/
+    flake8 --config ./lint-configs/.flake8 src/ tests/ examples/
+    pylint -E --rcfile=./lint-configs/.pylintrc src/ tests/ examples/
     mypy --no-incremental --config-file lint-configs/mypy.ini src/ tests/unit/ tests/integration/
 
 [testenv:mypy]
@@ -30,7 +31,7 @@ deps = -r requirements-test.txt
        mypy
        mypy-protobuf
 commands =
-    mypy --no-incremental --config-file lint-configs/mypy.ini src/ tests/unit/ tests/integration/
+    mypy --no-incremental --config-file lint-configs/mypy.ini src/ tests/unit/ tests/integration/ examples/
 
 [testenv:py3.7-integration-tests]
 commands =


### PR DESCRIPTION
This pull request adds a simple HTTP service which allows user to store and retrieve arbitrary Protobuf objects from Google Datastore.

It works by accepting and returning JSON serialized version of the arbitrary Protobuf objects. Internally it works by first translating JSON to custom Protobuf object instance, translating this instance into the Entity PB object (using this translator library) and storing it inside the datastore.

Example usage:

```bash
$ curl -vvv http://127.0.0.1:5000/datastore/put/key1 -X POST -H "Content-Type: application/json" --data '{"model_name": "tests.generated.example_pb2.ExampleDBModel", "json_string": "{\"int32Key\": 1000, \"stringKey\": \"foo bar\"}"}'
$ curl -X GET "http://127.0.0.1:5000/datastore/get/key1?model_name=tests.generated.example_pb2.ExampleDBModel"
{"json_string":"{\n  \"int32Key\": 1000,\n  \"stringKey\": \"foo bar\"\n}","model_name":"tests.generated.example_pb2.ExampleDBModel"}
```

Protobuf JSON serialization should be the same in all the programming languages. This allows us to do cross programming language testing and make sure those translator libraries for various programming languages work correctly (aka that the end result - serialized Entity PB object - is exactly the same).