### PR TITLE
Add optional strict mode to entity_pb_to_model_pb function

### DIFF
--- a/src/translator.py
+++ b/src/translator.py
@@ -39,7 +39,7 @@ __all__ = [
     'entity_pb_to_model_pb'
 ]
 
-# Type which represents a arbitrary ModelPb class which is a subclass of message.Message
+# Type which represents an arbitrary ModelPB class which is a subclass of message.Message
 T_model_pb = TypeVar('T_model_pb', bound=message.Message)
 
 

--- a/src/translator.py
+++ b/src/translator.py
@@ -16,6 +16,7 @@
 from typing import Any
 from typing import Type
 from typing import cast
+from typing import TypeVar
 from types import ModuleType
 from datetime import datetime
 
@@ -28,7 +29,6 @@ from google.protobuf import timestamp_pb2
 from google.protobuf import struct_pb2
 from google.protobuf import descriptor
 
-from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
 from google.protobuf.pyext._message import ScalarMapContainer
 from google.protobuf.pyext._message import RepeatedScalarContainer
 from google.protobuf.pyext._message import RepeatedCompositeContainer
@@ -38,6 +38,9 @@ __all__ = [
     'model_pb_with_key_to_entity_pb',
     'entity_pb_to_model_pb'
 ]
+
+# Type which represents a arbitrary ModelPb class which is a subclass of message.Message
+T_model_pb = TypeVar('T_model_pb', bound=message.Message)
 
 
 def model_pb_with_key_to_entity_pb(client, model_pb, exclude_falsy_values=False):
@@ -182,11 +185,11 @@ def model_pb_to_entity_pb(model_pb, exclude_falsy_values=False):
 
 
 def entity_pb_to_model_pb(model_pb_module,  # type: ModuleType
-                          model_pb_class,   # type: Type[GeneratedProtocolMessageType]
+                          model_pb_class,   # type: Type[T_model_pb]
                           entity_pb,        # type: entity_pb2.Entity
                           strict=False      # type: bool
                           ):
-    # type: (...) -> message.Message
+    # type: (...) -> T_model_pb
     """
     Translate Entity protobuf object to protobuf based database model object.
 

--- a/src/translator.py
+++ b/src/translator.py
@@ -181,8 +181,12 @@ def model_pb_to_entity_pb(model_pb, exclude_falsy_values=False):
     return entity_pb
 
 
-def entity_pb_to_model_pb(model_pb_module, model_pb_class, entity_pb, strict=False):
-    # type: (ModuleType, Type[GeneratedProtocolMessageType], entity_pb2.Entity, bool) -> message.Message
+def entity_pb_to_model_pb(model_pb_module,  # type: ModuleType
+                          model_pb_class,   # type: Type[GeneratedProtocolMessageType]
+                          entity_pb,        # type: entity_pb2.Entity
+                          strict=False      # type: bool
+                          ):
+    # type: (...) -> message.Message
     """
     Translate Entity protobuf object to protobuf based database model object.
 
@@ -205,7 +209,7 @@ def entity_pb_to_model_pb(model_pb_module, model_pb_class, entity_pb, strict=Fal
         if prop_name not in model_pb_field_names:
             if strict:
                 msg = ('Database object contains field "%s" which is not defined on the database '
-                        'model class "%s"' % (prop_name, model_pb.DESCRIPTOR.name))
+                       'model class "%s"' % (prop_name, model_pb.DESCRIPTOR.name))
                 raise ValueError(msg)
             else:
                 continue

--- a/tests/integration/test_translator.py
+++ b/tests/integration/test_translator.py
@@ -66,11 +66,10 @@ class GoogleDatastoreTranslatorIntegrationTestCase(unittest.TestCase):
             requests.get(os.environ['DATASTORE_HOST'], timeout=1)
         except requests.exceptions.ConnectionError as e:
             raise ValueError('Can\'t reach "%s". Make sure Google Cloud Datastore emulator is '
-                    'running and listening on "%s": %s.\n\nYou can start emulator'
-                    'using "%s" command.'%
-                             (os.environ['DATASTORE_HOST'],
-                                 os.environ['DATASTORE_EMULATOR_HOST'], str(e),
-                                 START_EMULATOR_STRING))
+                    'running and listening on "%s": %s.\n\nYou can start emulator using "%s" '
+                    'command.' % (os.environ['DATASTORE_HOST'],
+                                  os.environ['DATASTORE_EMULATOR_HOST'], str(e),
+                                  START_EMULATOR_STRING))
 
         # Instantiate client with mock credentials object
         self.client = datastore.Client(credentials=EmulatorCreds(),

--- a/tests/integration/test_translator.py
+++ b/tests/integration/test_translator.py
@@ -39,6 +39,10 @@ __all__ = [
     'GoogleDatastoreTranslatorIntegrationTestCase'
 ]
 
+START_EMULATOR_STRING = """
+gcloud beta emulators datastore start --host-port=127.0.0.1:8081 --no-store-on-disk
+""".strip()
+
 
 class GoogleDatastoreTranslatorIntegrationTestCase(unittest.TestCase):
     """
@@ -57,8 +61,20 @@ class GoogleDatastoreTranslatorIntegrationTestCase(unittest.TestCase):
         os.environ['DATASTORE_EMULATOR_HOST_PATH'] = 'localhost:8081/datastore'
         os.environ['DATASTORE_HOST'] = 'http://localhost:8081'
 
+        # 1. Verify datastore emulator is running
+        try:
+            requests.get(os.environ['DATASTORE_HOST'], timeout=1)
+        except requests.exceptions.ConnectionError as e:
+            raise ValueError('Can\'t reach "%s". Make sure Google Cloud Datastore emulator is '
+                    'running and listening on "%s": %s.\n\nYou can start emulator'
+                    'using "%s" command.'%
+                             (os.environ['DATASTORE_HOST'],
+                                 os.environ['DATASTORE_EMULATOR_HOST'], str(e),
+                                 START_EMULATOR_STRING))
+
         # Instantiate client with mock credentials object
-        self.client = datastore.Client(credentials=EmulatorCreds(), _http=requests.Session())
+        self.client = datastore.Client(credentials=EmulatorCreds(),
+                _http=requests.Session())
         self._clear_datastore()
 
     def tearDown(self):

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -287,15 +287,16 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         # object should be ignored
         example_pb = entity_pb_to_model_pb(example_pb2, example_pb2.ExampleDBModel, entity_pb)
 
-        self.assertEqual(example_pb.string_key, 'test value')  # type: ignore
-        self.assertEqual(example_pb.int32_key, 20)  # type: ignore
+        self.assertEqual(example_pb.string_key, 'test value')
+        self.assertEqual(example_pb.int32_key, 20)
+        self.assertEqual(example_pb.int32_key, 20)
         self.assertRaises(AttributeError, getattr, example_pb, 'non_valid_key')
 
         example_pb = entity_pb_to_model_pb(example_pb2, example_pb2.ExampleDBModel, entity_pb,
                                           strict=False)
 
-        self.assertEqual(example_pb.string_key, 'test value')  # type: ignore
-        self.assertEqual(example_pb.int32_key, 20)  # type: ignore
+        self.assertEqual(example_pb.string_key, 'test value')
+        self.assertEqual(example_pb.int32_key, 20)
         self.assertRaises(AttributeError, getattr, example_pb, 'non_valid_key')
 
         # 2. Using strict mode, exception should be thrown

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -287,8 +287,15 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         # object should be ignored
         example_pb = entity_pb_to_model_pb(example_pb2, example_pb2.ExampleDBModel, entity_pb)
 
-        self.assertEqual(example_pb.string_key, 'test value')
-        self.assertEqual(example_pb.int32_key, 20)
+        self.assertEqual(example_pb.string_key, 'test value')  # type: ignore
+        self.assertEqual(example_pb.int32_key, 20)  # type: ignore
+        self.assertRaises(AttributeError, getattr, example_pb, 'non_valid_key')
+
+        example_pb = entity_pb_to_model_pb(example_pb2, example_pb2.ExampleDBModel, entity_pb,
+                                          strict=False)
+
+        self.assertEqual(example_pb.string_key, 'test value')  # type: ignore
+        self.assertEqual(example_pb.int32_key, 20)  # type: ignore
         self.assertRaises(AttributeError, getattr, example_pb, 'non_valid_key')
 
         # 2. Using strict mode, exception should be thrown

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -275,6 +275,28 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         self.assertRaisesRegexp(ValueError, expected_msg, model_pb_with_key_to_entity_pb, client,
                                 example_pb)
 
+    def test_entity_pb_to_model_pb_strict_mode(self):
+        # type: () -> None
+
+        entity_pb = entity_pb2.Entity()
+        entity_native = datastore.Entity()
+        entity_native.update({'string_key': 'test value', 'int32_key': 20, 'non_valid_key': 'bar'})
+        entity_pb = datastore.helpers.entity_to_protobuf(entity_native)
+
+        # 1. Not using strict mode. Field which is available on the Entity object, but not model
+        # object should be ignored
+        example_pb = entity_pb_to_model_pb(example_pb2, example_pb2.ExampleDBModel, entity_pb)
+
+        self.assertEqual(example_pb.string_key, 'test value')
+        self.assertEqual(example_pb.int32_key, 20)
+        self.assertRaises(AttributeError, getattr, example_pb, 'non_valid_key')
+
+        # 2. Using strict mode, exception should be thrown
+        expected_msg = ('Database object contains field "non_valid_key" which is not defined on '
+                        'the database model class "ExampleDBModel"')
+        self.assertRaisesRegexp(ValueError, expected_msg, entity_pb_to_model_pb, example_pb2,
+                                example_pb2.ExampleDBModel, entity_pb, strict=True)
+
     def assertEntityPbHasPopulatedField(self, entity_pb, field_name):
         # type: (entity_pb2.Entity, str) -> None
         """


### PR DESCRIPTION
This pull request adds optional strict mode to ``entity_pb_to_model_pb`` function.

When strict module is enabled, that function will throw if it encounters a field on a datastore Entity object which is not defined on the db model class.

As a small testing improvement, I also added a small change which makes sure integration tests fail fast and loudly if Cloud Datastore emulator is not running.