### PR TITLE
Implement support for google.type.LatLng field type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# v0.1.1 - June 11th, 2019
+
+- Implement support for ``geo_point_value`` and ``google.type.LatLng`` field
+  type.
+
+  Now all the field types which are supported by Google Datastore are also
+  supported by this library.
+
 # v0.1.0 - June 5th, 2019
 
 - Initial release which exposes the following public functions:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library allows you to store arbitrary Protobuf message objects inside the G
 It exposes methods for translating arbitrary Protobuf message objects to Entity Protobuf objects
 which are used by Google Datastore and vice-versa.
 
-It supports all the native types except GeoPoint as supported by the Google Datastore.
+It supports all the native which are supported by the Google Datastore.
 
 ## Why, Motivation
 
@@ -33,7 +33,7 @@ Right now the library supports the following Protobuf field types and functional
 * All the simple types (string, int32, int64, double, float, bytes, bool, enum)
 * Scalar / container types (map, repeated)
 * Complex types from Protobuf standard library (``google.protobuf.Timestamp``,
-  ``google.Protobuf.Struct``)
+  ``google.Protobuf.Struct``, ``google.types.LatLng``)
 * Using imports and referencing types from different Protobuf definition files. For example,
   you can have Protobuf message definition called ``Model1DB`` inside file ``model1.proto`` which
   has a field which references ``Model2DB`` from ``model2.proto`` file.

--- a/lint-configs/mypy.ini
+++ b/lint-configs/mypy.ini
@@ -5,6 +5,9 @@ show_error_context = True
 show_column_numbers = True
 
 # List of ignore files for packages and libraries which don't have type hints
+[mypy-google.type]
+ignore_missing_imports = True
+
 [mypy-google.cloud.*]
 ignore_missing_imports = True
 

--- a/protobuf/example.proto
+++ b/protobuf/example.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/latlng.proto";
 
 import "example2.proto";
 import "models/example3.proto";
@@ -63,6 +64,7 @@ message ExampleDBModel {
 
     // Other special types
     google.protobuf.NullValue null_key = 13;
+    google.type.LatLng geo_point_key = 17;
 }
 
 // DB model which references types (Protobuf definitions) from another file.

--- a/protobuf/google/type/latlng.proto
+++ b/protobuf/google/type/latlng.proto
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.type;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/type/latlng;latlng";
+option java_multiple_files = true;
+option java_outer_classname = "LatLngProto";
+option java_package = "com.google.type";
+option objc_class_prefix = "GTP";
+
+
+// An object representing a latitude/longitude pair. This is expressed as a pair
+// of doubles representing degrees latitude and degrees longitude. Unless
+// specified otherwise, this must conform to the
+// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+// standard</a>. Values must be within normalized ranges.
+message LatLng {
+  // The latitude in degrees. It must be in the range [-90.0, +90.0].
+  double latitude = 1;
+
+  // The longitude in degrees. It must be in the range [-180.0, +180.0].
+  double longitude = 2;
+}

--- a/tests/generated/example2_pb2.pyi
+++ b/tests/generated/example2_pb2.pyi
@@ -13,7 +13,6 @@ from typing import (
     Optional as typing___Optional,
     Text as typing___Text,
     Tuple as typing___Tuple,
-    cast as typing___cast,
 )
 
 from typing_extensions import (
@@ -33,15 +32,19 @@ class ExampleReferencedEnum(int):
     def values(cls) -> typing___List[ExampleReferencedEnum]: ...
     @classmethod
     def items(cls) -> typing___List[typing___Tuple[str, ExampleReferencedEnum]]: ...
-KEY0 = typing___cast(ExampleReferencedEnum, 0)
-KEY1 = typing___cast(ExampleReferencedEnum, 1)
-KEY2 = typing___cast(ExampleReferencedEnum, 2)
+    KEY0: typing_extensions___Literal[0]
+    KEY1: typing_extensions___Literal[1]
+    KEY2: typing_extensions___Literal[2]
+KEY0: typing_extensions___Literal[0]
+KEY1: typing_extensions___Literal[1]
+KEY2: typing_extensions___Literal[2]
 
 class ExampleReferencedType(google___protobuf___message___Message):
     key_1 = ... # type: typing___Text
     key_2 = ... # type: typing___Text
 
     def __init__(self,
+        *,
         key_1 : typing___Optional[typing___Text] = None,
         key_2 : typing___Optional[typing___Text] = None,
         ) -> None: ...
@@ -52,4 +55,4 @@ class ExampleReferencedType(google___protobuf___message___Message):
     if sys.version_info >= (3,):
         def ClearField(self, field_name: typing_extensions___Literal[u"key_1",u"key_2"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[b"key_1",b"key_2"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"key_1",b"key_1",u"key_2",b"key_2"]) -> None: ...

--- a/tests/generated/example_pb2.py
+++ b/tests/generated/example_pb2.py
@@ -16,6 +16,7 @@ _sym_db = _symbol_database.Default()
 
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
+from google.type import latlng_pb2 as google_dot_type_dot_latlng__pb2
 import example2_pb2 as example2__pb2
 from models import example3_pb2 as models_dot_example3__pb2
 
@@ -25,9 +26,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\rexample.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0e\x65xample2.proto\x1a\x15models/example3.proto\";\n\x12\x45xampleNestedModel\x12\x12\n\nstring_key\x18\x01 \x01(\t\x12\x11\n\tint32_key\x18\x02 \x01(\x05\"K\n\x15\x45xampleDBModelWithKey\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nstring_key\x18\x02 \x01(\t\x12\x11\n\tint32_key\x18\x03 \x01(\x05\"\x9b\x05\n\x0e\x45xampleDBModel\x12\x11\n\tint32_key\x18\x01 \x01(\x05\x12\x12\n\nstring_key\x18\x02 \x01(\t\x12\x10\n\x08\x62ool_key\x18\x03 \x01(\x08\x12\x11\n\tbytes_key\x18\x04 \x01(\x0c\x12\x12\n\ndouble_key\x18\x0e \x01(\x01\x12\x11\n\tfloat_key\x18\x0f \x01(\x02\x12\x11\n\tint64_key\x18\x10 \x01(\x03\x12?\n\x11map_string_string\x18\x05 \x03(\x0b\x32$.ExampleDBModel.MapStringStringEntry\x12=\n\x10map_string_int32\x18\x06 \x03(\x0b\x32#.ExampleDBModel.MapStringInt32Entry\x12\x18\n\x10string_array_key\x18\x07 \x03(\t\x12\x17\n\x0fint32_array_key\x18\x08 \x03(\x05\x12.\n\x11\x63omplex_array_key\x18\t \x03(\x0b\x32\x13.ExampleNestedModel\x12#\n\x08\x65num_key\x18\n \x01(\x0e\x32\x11.ExampleEnumModel\x12\x31\n\rtimestamp_key\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\nstruct_key\x18\x0c \x01(\x0b\x32\x17.google.protobuf.Struct\x12,\n\x08null_key\x18\r \x01(\x0e\x32\x1a.google.protobuf.NullValue\x1a\x36\n\x14MapStringStringEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x35\n\x13MapStringInt32Entry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x05:\x02\x38\x01\"\xdf\x01\n ExampleWithReferencedTypeDBModel\x12\x12\n\nstring_key\x18\x01 \x01(\t\x12*\n\x0freferenced_enum\x18\x02 \x01(\x0e\x32\x11.ExampleEnumModel\x12\x33\n\x13referenced_type_key\x18\x03 \x01(\x0b\x32\x16.ExampleReferencedType\x12\x46\n\x1breferenced_package_type_key\x18\x04 \x01(\x0b\x32!.models.ExampleWithPackageDBModel\"M\n\x1e\x45xampleWithNestedStructDBModel\x12+\n\nstruct_key\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct*3\n\x10\x45xampleEnumModel\x12\t\n\x05\x45NUM0\x10\x00\x12\t\n\x05\x45NUM1\x10\x01\x12\t\n\x05\x45NUM2\x10\x02\x62\x06proto3')
+  serialized_pb=_b('\n\rexample.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18google/type/latlng.proto\x1a\x0e\x65xample2.proto\x1a\x15models/example3.proto\";\n\x12\x45xampleNestedModel\x12\x12\n\nstring_key\x18\x01 \x01(\t\x12\x11\n\tint32_key\x18\x02 \x01(\x05\"K\n\x15\x45xampleDBModelWithKey\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x12\n\nstring_key\x18\x02 \x01(\t\x12\x11\n\tint32_key\x18\x03 \x01(\x05\"\xc7\x05\n\x0e\x45xampleDBModel\x12\x11\n\tint32_key\x18\x01 \x01(\x05\x12\x12\n\nstring_key\x18\x02 \x01(\t\x12\x10\n\x08\x62ool_key\x18\x03 \x01(\x08\x12\x11\n\tbytes_key\x18\x04 \x01(\x0c\x12\x12\n\ndouble_key\x18\x0e \x01(\x01\x12\x11\n\tfloat_key\x18\x0f \x01(\x02\x12\x11\n\tint64_key\x18\x10 \x01(\x03\x12?\n\x11map_string_string\x18\x05 \x03(\x0b\x32$.ExampleDBModel.MapStringStringEntry\x12=\n\x10map_string_int32\x18\x06 \x03(\x0b\x32#.ExampleDBModel.MapStringInt32Entry\x12\x18\n\x10string_array_key\x18\x07 \x03(\t\x12\x17\n\x0fint32_array_key\x18\x08 \x03(\x05\x12.\n\x11\x63omplex_array_key\x18\t \x03(\x0b\x32\x13.ExampleNestedModel\x12#\n\x08\x65num_key\x18\n \x01(\x0e\x32\x11.ExampleEnumModel\x12\x31\n\rtimestamp_key\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\nstruct_key\x18\x0c \x01(\x0b\x32\x17.google.protobuf.Struct\x12,\n\x08null_key\x18\r \x01(\x0e\x32\x1a.google.protobuf.NullValue\x12*\n\rgeo_point_key\x18\x11 \x01(\x0b\x32\x13.google.type.LatLng\x1a\x36\n\x14MapStringStringEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x35\n\x13MapStringInt32Entry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x05:\x02\x38\x01\"\xdf\x01\n ExampleWithReferencedTypeDBModel\x12\x12\n\nstring_key\x18\x01 \x01(\t\x12*\n\x0freferenced_enum\x18\x02 \x01(\x0e\x32\x11.ExampleEnumModel\x12\x33\n\x13referenced_type_key\x18\x03 \x01(\x0b\x32\x16.ExampleReferencedType\x12\x46\n\x1breferenced_package_type_key\x18\x04 \x01(\x0b\x32!.models.ExampleWithPackageDBModel\"M\n\x1e\x45xampleWithNestedStructDBModel\x12+\n\nstruct_key\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct*3\n\x10\x45xampleEnumModel\x12\t\n\x05\x45NUM0\x10\x00\x12\t\n\x05\x45NUM1\x10\x01\x12\t\n\x05\x45NUM2\x10\x02\x62\x06proto3')
   ,
-  dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,example2__pb2.DESCRIPTOR,models_dot_example3__pb2.DESCRIPTOR,])
+  dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_type_dot_latlng__pb2.DESCRIPTOR,example2__pb2.DESCRIPTOR,models_dot_example3__pb2.DESCRIPTOR,])
 
 _EXAMPLEENUMMODEL = _descriptor.EnumDescriptor(
   name='ExampleEnumModel',
@@ -50,8 +51,8 @@ _EXAMPLEENUMMODEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1232,
-  serialized_end=1283,
+  serialized_start=1302,
+  serialized_end=1353,
 )
 _sym_db.RegisterEnumDescriptor(_EXAMPLEENUMMODEL)
 
@@ -95,8 +96,8 @@ _EXAMPLENESTEDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=119,
-  serialized_end=178,
+  serialized_start=145,
+  serialized_end=204,
 )
 
 
@@ -140,8 +141,8 @@ _EXAMPLEDBMODELWITHKEY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=180,
-  serialized_end=255,
+  serialized_start=206,
+  serialized_end=281,
 )
 
 
@@ -178,8 +179,8 @@ _EXAMPLEDBMODEL_MAPSTRINGSTRINGENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=816,
-  serialized_end=870,
+  serialized_start=886,
+  serialized_end=940,
 )
 
 _EXAMPLEDBMODEL_MAPSTRINGINT32ENTRY = _descriptor.Descriptor(
@@ -215,8 +216,8 @@ _EXAMPLEDBMODEL_MAPSTRINGINT32ENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=872,
-  serialized_end=925,
+  serialized_start=942,
+  serialized_end=995,
 )
 
 _EXAMPLEDBMODEL = _descriptor.Descriptor(
@@ -338,6 +339,13 @@ _EXAMPLEDBMODEL = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='geo_point_key', full_name='ExampleDBModel.geo_point_key', index=16,
+      number=17, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -350,8 +358,8 @@ _EXAMPLEDBMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=258,
-  serialized_end=925,
+  serialized_start=284,
+  serialized_end=995,
 )
 
 
@@ -402,8 +410,8 @@ _EXAMPLEWITHREFERENCEDTYPEDBMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=928,
-  serialized_end=1151,
+  serialized_start=998,
+  serialized_end=1221,
 )
 
 
@@ -433,8 +441,8 @@ _EXAMPLEWITHNESTEDSTRUCTDBMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1153,
-  serialized_end=1230,
+  serialized_start=1223,
+  serialized_end=1300,
 )
 
 _EXAMPLEDBMODEL_MAPSTRINGSTRINGENTRY.containing_type = _EXAMPLEDBMODEL
@@ -446,6 +454,7 @@ _EXAMPLEDBMODEL.fields_by_name['enum_key'].enum_type = _EXAMPLEENUMMODEL
 _EXAMPLEDBMODEL.fields_by_name['timestamp_key'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _EXAMPLEDBMODEL.fields_by_name['struct_key'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT
 _EXAMPLEDBMODEL.fields_by_name['null_key'].enum_type = google_dot_protobuf_dot_struct__pb2._NULLVALUE
+_EXAMPLEDBMODEL.fields_by_name['geo_point_key'].message_type = google_dot_type_dot_latlng__pb2._LATLNG
 _EXAMPLEWITHREFERENCEDTYPEDBMODEL.fields_by_name['referenced_enum'].enum_type = _EXAMPLEENUMMODEL
 _EXAMPLEWITHREFERENCEDTYPEDBMODEL.fields_by_name['referenced_type_key'].message_type = example2__pb2._EXAMPLEREFERENCEDTYPE
 _EXAMPLEWITHREFERENCEDTYPEDBMODEL.fields_by_name['referenced_package_type_key'].message_type = models_dot_example3__pb2._EXAMPLEWITHPACKAGEDBMODEL

--- a/tests/generated/example_pb2.pyi
+++ b/tests/generated/example_pb2.pyi
@@ -26,6 +26,10 @@ from google.protobuf.timestamp_pb2 import (
     Timestamp as google___protobuf___timestamp_pb2___Timestamp,
 )
 
+from google.type.latlng_pb2 import (
+    LatLng as google___type___latlng_pb2___LatLng,
+)
+
 from models.example3_pb2 import (
     ExampleWithPackageDBModel as models___example3_pb2___ExampleWithPackageDBModel,
 )
@@ -38,7 +42,6 @@ from typing import (
     Optional as typing___Optional,
     Text as typing___Text,
     Tuple as typing___Tuple,
-    cast as typing___cast,
 )
 
 from typing_extensions import (
@@ -58,15 +61,19 @@ class ExampleEnumModel(int):
     def values(cls) -> typing___List[ExampleEnumModel]: ...
     @classmethod
     def items(cls) -> typing___List[typing___Tuple[str, ExampleEnumModel]]: ...
-ENUM0 = typing___cast(ExampleEnumModel, 0)
-ENUM1 = typing___cast(ExampleEnumModel, 1)
-ENUM2 = typing___cast(ExampleEnumModel, 2)
+    ENUM0: typing_extensions___Literal[0]
+    ENUM1: typing_extensions___Literal[1]
+    ENUM2: typing_extensions___Literal[2]
+ENUM0: typing_extensions___Literal[0]
+ENUM1: typing_extensions___Literal[1]
+ENUM2: typing_extensions___Literal[2]
 
 class ExampleNestedModel(google___protobuf___message___Message):
     string_key = ... # type: typing___Text
     int32_key = ... # type: int
 
     def __init__(self,
+        *,
         string_key : typing___Optional[typing___Text] = None,
         int32_key : typing___Optional[int] = None,
         ) -> None: ...
@@ -77,7 +84,7 @@ class ExampleNestedModel(google___protobuf___message___Message):
     if sys.version_info >= (3,):
         def ClearField(self, field_name: typing_extensions___Literal[u"int32_key",u"string_key"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[b"int32_key",b"string_key"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"int32_key",b"int32_key",u"string_key",b"string_key"]) -> None: ...
 
 class ExampleDBModelWithKey(google___protobuf___message___Message):
     key = ... # type: typing___Text
@@ -85,6 +92,7 @@ class ExampleDBModelWithKey(google___protobuf___message___Message):
     int32_key = ... # type: int
 
     def __init__(self,
+        *,
         key : typing___Optional[typing___Text] = None,
         string_key : typing___Optional[typing___Text] = None,
         int32_key : typing___Optional[int] = None,
@@ -96,7 +104,7 @@ class ExampleDBModelWithKey(google___protobuf___message___Message):
     if sys.version_info >= (3,):
         def ClearField(self, field_name: typing_extensions___Literal[u"int32_key",u"key",u"string_key"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[b"int32_key",b"key",b"string_key"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"int32_key",b"int32_key",u"key",b"key",u"string_key",b"string_key"]) -> None: ...
 
 class ExampleDBModel(google___protobuf___message___Message):
     class MapStringStringEntry(google___protobuf___message___Message):
@@ -104,6 +112,7 @@ class ExampleDBModel(google___protobuf___message___Message):
         value = ... # type: typing___Text
 
         def __init__(self,
+            *,
             key : typing___Optional[typing___Text] = None,
             value : typing___Optional[typing___Text] = None,
             ) -> None: ...
@@ -114,13 +123,14 @@ class ExampleDBModel(google___protobuf___message___Message):
         if sys.version_info >= (3,):
             def ClearField(self, field_name: typing_extensions___Literal[u"key",u"value"]) -> None: ...
         else:
-            def ClearField(self, field_name: typing_extensions___Literal[b"key",b"value"]) -> None: ...
+            def ClearField(self, field_name: typing_extensions___Literal[u"key",b"key",u"value",b"value"]) -> None: ...
 
     class MapStringInt32Entry(google___protobuf___message___Message):
         key = ... # type: typing___Text
         value = ... # type: int
 
         def __init__(self,
+            *,
             key : typing___Optional[typing___Text] = None,
             value : typing___Optional[int] = None,
             ) -> None: ...
@@ -131,7 +141,7 @@ class ExampleDBModel(google___protobuf___message___Message):
         if sys.version_info >= (3,):
             def ClearField(self, field_name: typing_extensions___Literal[u"key",u"value"]) -> None: ...
         else:
-            def ClearField(self, field_name: typing_extensions___Literal[b"key",b"value"]) -> None: ...
+            def ClearField(self, field_name: typing_extensions___Literal[u"key",b"key",u"value",b"value"]) -> None: ...
 
     int32_key = ... # type: int
     string_key = ... # type: typing___Text
@@ -160,7 +170,11 @@ class ExampleDBModel(google___protobuf___message___Message):
     @property
     def struct_key(self) -> google___protobuf___struct_pb2___Struct: ...
 
+    @property
+    def geo_point_key(self) -> google___type___latlng_pb2___LatLng: ...
+
     def __init__(self,
+        *,
         int32_key : typing___Optional[int] = None,
         string_key : typing___Optional[typing___Text] = None,
         bool_key : typing___Optional[bool] = None,
@@ -177,17 +191,18 @@ class ExampleDBModel(google___protobuf___message___Message):
         timestamp_key : typing___Optional[google___protobuf___timestamp_pb2___Timestamp] = None,
         struct_key : typing___Optional[google___protobuf___struct_pb2___Struct] = None,
         null_key : typing___Optional[google___protobuf___struct_pb2___NullValue] = None,
+        geo_point_key : typing___Optional[google___type___latlng_pb2___LatLng] = None,
         ) -> None: ...
     @classmethod
     def FromString(cls, s: bytes) -> ExampleDBModel: ...
     def MergeFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     if sys.version_info >= (3,):
-        def HasField(self, field_name: typing_extensions___Literal[u"struct_key",u"timestamp_key"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[u"bool_key",u"bytes_key",u"complex_array_key",u"double_key",u"enum_key",u"float_key",u"int32_array_key",u"int32_key",u"int64_key",u"map_string_int32",u"map_string_string",u"null_key",u"string_array_key",u"string_key",u"struct_key",u"timestamp_key"]) -> None: ...
+        def HasField(self, field_name: typing_extensions___Literal[u"geo_point_key",u"struct_key",u"timestamp_key"]) -> bool: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"bool_key",u"bytes_key",u"complex_array_key",u"double_key",u"enum_key",u"float_key",u"geo_point_key",u"int32_array_key",u"int32_key",u"int64_key",u"map_string_int32",u"map_string_string",u"null_key",u"string_array_key",u"string_key",u"struct_key",u"timestamp_key"]) -> None: ...
     else:
-        def HasField(self, field_name: typing_extensions___Literal[u"struct_key",b"struct_key",u"timestamp_key",b"timestamp_key"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[b"bool_key",b"bytes_key",b"complex_array_key",b"double_key",b"enum_key",b"float_key",b"int32_array_key",b"int32_key",b"int64_key",b"map_string_int32",b"map_string_string",b"null_key",b"string_array_key",b"string_key",b"struct_key",b"timestamp_key"]) -> None: ...
+        def HasField(self, field_name: typing_extensions___Literal[u"geo_point_key",b"geo_point_key",u"struct_key",b"struct_key",u"timestamp_key",b"timestamp_key"]) -> bool: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"bool_key",b"bool_key",u"bytes_key",b"bytes_key",u"complex_array_key",b"complex_array_key",u"double_key",b"double_key",u"enum_key",b"enum_key",u"float_key",b"float_key",u"geo_point_key",b"geo_point_key",u"int32_array_key",b"int32_array_key",u"int32_key",b"int32_key",u"int64_key",b"int64_key",u"map_string_int32",b"map_string_int32",u"map_string_string",b"map_string_string",u"null_key",b"null_key",u"string_array_key",b"string_array_key",u"string_key",b"string_key",u"struct_key",b"struct_key",u"timestamp_key",b"timestamp_key"]) -> None: ...
 
 class ExampleWithReferencedTypeDBModel(google___protobuf___message___Message):
     string_key = ... # type: typing___Text
@@ -200,6 +215,7 @@ class ExampleWithReferencedTypeDBModel(google___protobuf___message___Message):
     def referenced_package_type_key(self) -> models___example3_pb2___ExampleWithPackageDBModel: ...
 
     def __init__(self,
+        *,
         string_key : typing___Optional[typing___Text] = None,
         referenced_enum : typing___Optional[ExampleEnumModel] = None,
         referenced_type_key : typing___Optional[example2_pb2___ExampleReferencedType] = None,
@@ -214,7 +230,7 @@ class ExampleWithReferencedTypeDBModel(google___protobuf___message___Message):
         def ClearField(self, field_name: typing_extensions___Literal[u"referenced_enum",u"referenced_package_type_key",u"referenced_type_key",u"string_key"]) -> None: ...
     else:
         def HasField(self, field_name: typing_extensions___Literal[u"referenced_package_type_key",b"referenced_package_type_key",u"referenced_type_key",b"referenced_type_key"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[b"referenced_enum",b"referenced_package_type_key",b"referenced_type_key",b"string_key"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"referenced_enum",b"referenced_enum",u"referenced_package_type_key",b"referenced_package_type_key",u"referenced_type_key",b"referenced_type_key",u"string_key",b"string_key"]) -> None: ...
 
 class ExampleWithNestedStructDBModel(google___protobuf___message___Message):
 
@@ -222,6 +238,7 @@ class ExampleWithNestedStructDBModel(google___protobuf___message___Message):
     def struct_key(self) -> google___protobuf___struct_pb2___Struct: ...
 
     def __init__(self,
+        *,
         struct_key : typing___Optional[google___protobuf___struct_pb2___Struct] = None,
         ) -> None: ...
     @classmethod
@@ -233,4 +250,4 @@ class ExampleWithNestedStructDBModel(google___protobuf___message___Message):
         def ClearField(self, field_name: typing_extensions___Literal[u"struct_key"]) -> None: ...
     else:
         def HasField(self, field_name: typing_extensions___Literal[u"struct_key",b"struct_key"]) -> bool: ...
-        def ClearField(self, field_name: typing_extensions___Literal[b"struct_key"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"struct_key",b"struct_key"]) -> None: ...

--- a/tests/generated/models/example3_pb2.pyi
+++ b/tests/generated/models/example3_pb2.pyi
@@ -18,6 +18,7 @@ class ExampleWithPackageDBModel(google___protobuf___message___Message):
     string_key = ... # type: typing___Text
 
     def __init__(self,
+        *,
         string_key : typing___Optional[typing___Text] = None,
         ) -> None: ...
     @classmethod
@@ -27,4 +28,4 @@ class ExampleWithPackageDBModel(google___protobuf___message___Message):
     if sys.version_info >= (3,):
         def ClearField(self, field_name: typing_extensions___Literal[u"string_key"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[b"string_key"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"string_key",b"string_key"]) -> None: ...

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -17,6 +17,8 @@ import datetime
 
 import google.auth
 import pytz
+from google.type import latlng_pb2
+from google.cloud.datastore.helpers import GeoPoint
 
 from tests.generated import example_pb2
 
@@ -67,8 +69,10 @@ EXAMPLE_DICT_POPULATED = {
         }
     },
     'timestamp_key': dt,
+    'geo_point_key': GeoPoint(-20.2, +160.5),
     'null_key': None
 }
+geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)
 
 EXAMPLE_DICT_DEFAULT_VALUES = {
     'bool_key': False,
@@ -126,6 +130,9 @@ EXAMPLE_PB_POPULATED.struct_key.update({
         'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}]
     }
 })
+
+geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)
+EXAMPLE_PB_POPULATED.geo_point_key.CopyFrom(geo_point_value)
 
 # Ezample object which explicitly provides values for all the fields which are the same as
 # the default values

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -18,6 +18,7 @@ import unittest
 import requests
 from google.cloud import datastore
 from google.cloud.datastore_v1.proto import entity_pb2
+from google.type import latlng_pb2
 
 from tests.generated import example_pb2
 from tests.generated import example2_pb2
@@ -233,6 +234,19 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
             .properties['key2'].string_value,
             'value2')
 
+        geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)
+
+        example_pb = example_pb2.ExampleDBModel()
+        example_pb.geo_point_key.CopyFrom(geo_point_value)
+
+        entity_pb_serialized = model_pb_to_entity_pb(model_pb=example_pb, exclude_falsy_values=True)
+        self.assertEntityPbHasPopulatedField(entity_pb_serialized,
+                'geo_point_key')
+        self.assertEqual(entity_pb_serialized.properties['geo_point_key'].geo_point_value.latitude,
+            -20.2)
+        self.assertEqual(entity_pb_serialized.properties['geo_point_key'].geo_point_value.longitude,
+            +160.5)
+
     def test_model_pb_with_key_to_entity_pb(self):
         # type: () -> None
         client = datastore.Client(credentials=EmulatorCreds(), _http=requests.Session(),
@@ -305,6 +319,18 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
                         'the database model class "ExampleDBModel"')
         self.assertRaisesRegexp(ValueError, expected_msg, entity_pb_to_model_pb,
                                 example_pb2.ExampleDBModel, entity_pb, strict=True)
+
+    def test_entity_pb_to_model_pb_geopoint_type(self):
+        entity_pb = entity_pb2.Entity()
+
+        latlng_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)
+
+        geo_point_value = entity_pb.properties.get_or_create('geo_point_key')
+        geo_point_value.geo_point_value.CopyFrom(latlng_value)
+
+        model_pb = entity_pb_to_model_pb(example_pb2.ExampleDBModel, entity_pb)
+        self.assertEqual(model_pb.geo_point_key.latitude, -20.2)
+        self.assertEqual(model_pb.geo_point_key.longitude, +160.5)
 
     def test_model_pb_to_entity_pb_referenced_type(self):
         # Test a scenario where model pb references a type from another protobuf file

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -332,6 +332,15 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         self.assertEqual(model_pb.geo_point_key.latitude, -20.2)
         self.assertEqual(model_pb.geo_point_key.longitude, +160.5)
 
+        latlng_value = latlng_pb2.LatLng(latitude=0.0, longitude=0.0)
+
+        geo_point_value = entity_pb.properties.get_or_create('geo_point_key')
+        geo_point_value.geo_point_value.CopyFrom(latlng_value)
+
+        model_pb = entity_pb_to_model_pb(example_pb2.ExampleDBModel, entity_pb)
+        self.assertEqual(model_pb.geo_point_key.latitude, 0.0)
+        self.assertEqual(model_pb.geo_point_key.longitude, 0.0)
+
     def test_model_pb_to_entity_pb_referenced_type(self):
         # Test a scenario where model pb references a type from another protobuf file
         example_referenced_type_pb = example2_pb2.ExampleReferencedType()


### PR DESCRIPTION
This pull request implements support for ``google.type.LatLng`` field type aka ``geo_point_value`` field of the ``entity.Value`` Protobuf object.

Adding support for this field means that the library now supports all the field types which are supported by Google Datastore.

I don't think we will personally use this field type in the near future, but adding it makes the library complete (as far as supported field types go).