### PR TITLE
Write empty array values into the datastore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,16 @@
+# v0.1.2 - June 16th, 2019
+
+- Update ``model_pb_to_entity_pb`` method so it also includes empty array
+  values on the translated Entity Protobuf object. This way it's consistent
+  with other complex types (empty maps, etc). #11
+
 # v0.1.1 - June 11th, 2019
 
 - Implement support for ``geo_point_value`` and ``google.type.LatLng`` field
   type.
 
   Now all the field types which are supported by Google Datastore are also
-  supported by this library.
+  supported by this library. #9
 
 # v0.1.0 - June 5th, 2019
 

--- a/protobuf_cloud_datastore_translator/__init__.py
+++ b/protobuf_cloud_datastore_translator/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     'entity_pb_to_model_pb'
 ]
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 from .translator import model_pb_to_entity_pb
 from .translator import model_pb_with_key_to_entity_pb

--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -119,10 +119,9 @@ def model_pb_to_entity_pb(model_pb, exclude_falsy_values=False):
 
         if attr_type == 'array_value':
             if len(field_value) == 0:
-                # TODO: Should we include empty value?
-                # array_value = entity_pb2.ArrayValue(values=[])
-                # value_pb.array_value.CopyFrom(array_value)
-                continue
+                value_pb = datastore.helpers._new_value_pb(entity_pb, field_name)
+                array_value = entity_pb2.ArrayValue(values=[])
+                value_pb.array_value.CopyFrom(array_value)
             else:
                 value_pb = datastore.helpers._new_value_pb(entity_pb, field_name)
 
@@ -169,6 +168,9 @@ def model_pb_to_entity_pb(model_pb, exclude_falsy_values=False):
             if field_type.message_type.full_name == 'google.protobuf.Timestamp':
                 if str(field_value) == '':
                     # Value not set
+                    # TODO: Include default empty value?
+                    # value_pb = datastore.helpers._new_value_pb(entity_pb, field_name)
+                    # value_pb.timestamp_value.CopyFrom(field_value)
                     continue
 
                 value_pb = datastore.helpers._new_value_pb(entity_pb, field_name)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -86,7 +86,10 @@ EXAMPLE_DICT_DEFAULT_VALUES = {
     'bytes_key': b'',
     'null_key': None,
     'map_string_string': {},
-    'map_string_int32': {}
+    'map_string_int32': {},
+    'string_array_key': [],
+    'int32_array_key': [],
+    'complex_array_key': []
 }
 
 # pylint: disable=no-member


### PR DESCRIPTION
This pull request updates the translator library and ``model_pb_to_entity_pb`` method so it also writes empty array values in the datastore.

This way it's consistent with other complex types (empty maps, etc.) and with the Go translator library.