### PR TITLE
Add support for excluding model / entity fields from index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,6 @@ cache:
   directories:
     - $HOME/.cache/pip # pip cache
     - .benchmarks/  # py.test-benchmark result cache
-#    - .tox
+    # Go modules
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# v0.1.5 - TBA
+
+- Add support for new ``exclude_from_index`` argument to the
+  ``model_pb_to_entity_pb`` and ``model_pb_with_key_to_entity_pb`` method.
+  With this argument, user can specify a list of model / entity fields which
+  won't be indexed. #15
+
 # v0.1.4 - July 29th, 2019
 
 - Fix dynamic module import handling for referenced messages inside

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It may also work with Python 3.4 and 3.5, but we don't test against those versio
 
 This library exposes three main public methods.
 
-### ``model_pb_to_entity_pb(model_pb, exclude_falsy_values=False)``
+### ``model_pb_to_entity_pb(model_pb, exclude_falsy_values=False, exclude_from_index=None)``
 
 This method converts arbitrary Protobuf message objects to the Entity Protobuf object which can
 be used with Google Datastore.
@@ -102,7 +102,7 @@ entity = datastore.helpers.entity_from_protobuf(entity_pb)
 client.put(entity)
 ```
 
-### ``model_pb_with_key_to_entity_pb(client, model_pb, exclude_falsy_values=False)``
+### ``model_pb_with_key_to_entity_pb(client, model_pb, exclude_falsy_values=False, exclude_from_index=None)``
 
 As a convenience, this library also exposes ``model_pb_to_entity_pb`` method. This method assumes
 there is a special ``key`` string field on your Protobuf message which will act as an Entity

--- a/scripts/run-datastore-emulator.sh
+++ b/scripts/run-datastore-emulator.sh
@@ -28,11 +28,11 @@ EMULATOR_PID=$!
 sleep 5
 
 if ps -p ${EMULATOR_PID} > /dev/null; then
-    echo "MongoDB successfully started"
+    echo "Datastore emulator successfully started"
     tail -30 /tmp/emulator.log
     exit 0
 else
-    echo "Failed to start MongoDB"
+    echo "Failed to start Datastore emulator"
     tail -30 /tmp/emulator.log
     exit 1
 fi

--- a/tests/integration/test_translator.py
+++ b/tests/integration/test_translator.py
@@ -213,7 +213,6 @@ class GoogleDatastoreTranslatorIntegrationTestCase(BaseDatastoreIntegrationTestC
         entity_translated = datastore.helpers.entity_from_protobuf(entity_pb)
         self.assertEqual(entity_translated.exclude_from_indexes, set(['int32_key', 'bytes_key']))
 
-
         entity_translated.key = self.client.key('ExampleModel', 'exclude_from_indexes_2')
         self.client.put(entity_translated)
 

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -488,6 +488,30 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
                 .entity_value.properties['enum_key'].integer_value,
             example_pb2.ExampleEnumModel.ENUM0)
 
+    def test_model_pb_to_entity_pb_exclude_from_index_fields(self):
+        # type: () -> None
+        example_pb = example_pb2.ExampleDBModel()
+        example_pb.int32_key = 100
+        example_pb.string_key = 'string bar'
+        example_pb.bytes_key = b'foobarbytes'
+        example_pb.enum_key = 1  # type: ignore
+
+        # No exclude from index provided
+        entity_pb = model_pb_to_entity_pb(model_pb=example_pb)
+
+        for field_name in ['int32_key', 'string_key', 'bytes_key', 'enum_key']:
+            self.assertFalse(entity_pb.properties[field_name].exclude_from_indexes)
+
+        # Exclude from index provided for some fields
+        entity_pb = model_pb_to_entity_pb(model_pb=example_pb,
+                                          exclude_from_index=['int32_key', 'bytes_key'])
+
+        for field_name in ['int32_key', 'bytes_key']:
+            self.assertTrue(entity_pb.properties[field_name].exclude_from_indexes)
+
+        for field_name in ['string_key', 'enum_key']:
+            self.assertFalse(entity_pb.properties[field_name].exclude_from_indexes)
+
     def assertEntityPbHasPopulatedField(self, entity_pb, field_name):
         # type: (entity_pb2.Entity, str) -> None
         """

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -453,23 +453,26 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
             sorted(example_pb.SerializePartialToString()))
 
     def test_model_pb_to_entity_pb_repeated_referenced_field_with_enum_field(self):
+        # type: () -> None
         # Test a scenario where a repeated field references a nested type which contains an ENUM
         # and ensure that default enum value (0) is correctly set either when it's explicitly
         # provided or when it's not provided and a default value is used.
         example_pb = example_pb2.ExampleDBModel()
 
         example_placeholder_pb1 = example_pb2.ExampleNestedModel(string_key=u'value 1',
-            int32_key=12345, enum_key=example_pb2.ExampleEnumModel.ENUM2)
+            int32_key=12345)
+        example_placeholder_pb1.enum_key = example_pb2.ExampleEnumModel.ENUM2  # type: ignore
         # Enum with value 0 is explicitly provided
         example_placeholder_pb2 = example_pb2.ExampleNestedModel(string_key=u'value 2',
-           int32_key=5000, enum_key=example_pb2.ExampleEnumModel.ENUM0)
+           int32_key=5000)
+        example_placeholder_pb2.enum_key = example_pb2.ExampleEnumModel.ENUM2  # type: ignore
         # Enum value is not provided, default value 0 should be used
         example_placeholder_pb3 = example_pb2.ExampleNestedModel(string_key=u'value 3',
             int32_key=40)
 
-        example_pb.complex_array_key.append(example_placeholder_pb1)
-        example_pb.complex_array_key.append(example_placeholder_pb2)
-        example_pb.complex_array_key.append(example_placeholder_pb3)
+        example_pb.complex_array_key.append(example_placeholder_pb1)  # type: ignore
+        example_pb.complex_array_key.append(example_placeholder_pb2)  # type: ignore
+        example_pb.complex_array_key.append(example_placeholder_pb3)  # type: ignore
 
         self.assertEqual(example_pb.complex_array_key[0].enum_key, 2)
         self.assertEqual(example_pb.complex_array_key[1].enum_key, 0)

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -465,7 +465,7 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         # Enum with value 0 is explicitly provided
         example_placeholder_pb2 = example_pb2.ExampleNestedModel(string_key=u'value 2',
            int32_key=5000)
-        example_placeholder_pb2.enum_key = example_pb2.ExampleEnumModel.ENUM2  # type: ignore
+        example_placeholder_pb2.enum_key = example_pb2.ExampleEnumModel.ENUM0  # type: ignore
         # Enum value is not provided, default value 0 should be used
         example_placeholder_pb3 = example_pb2.ExampleNestedModel(string_key=u'value 3',
             int32_key=40)


### PR DESCRIPTION
This pull request adds support for excluding specified model / entity fields from index, meaning those fields won't be indexed.

All the entity fields are indexed by default, but indexes fields have some limitations such as maximum size which can only be 150 bytes.

In this PR I went with the "method argument" approach - user specifies which fields are not to be indexed by passing a list of field names to the ``model_pb_to_entity_pb`` method.

Ideally, this information would be stored with / on the Protobuf model definition itself, but proto syntax v3 doesn't support default values anymore so there is really no other nice way to handle that.

An alternative would be to utilize ``options`` functionality by writing a custom options extension. 

Something along those lines:

```protobuf
import "google/protobuf/descriptor.proto";

extend google.protobuf.MessageOptions {
  string exclude_from_indexes = 5000;
}

// Model which represents Execution object
message UserDBModel {
    option (exclude_from_indexes) = 'details,context';

    string name = 1;
    string address = 2;
    string details = 3;
    string context = 4;
```

And then handling this inside the translator library. I got that approach to work with the Python translator library, but it required some nasty code in the Go translator library to get it to work so I decided to go with the argument approach to begin with.