### PR TITLE
Correctly handle "null" values for nested google.protobuf.Struct fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# v0.1.6 - August 21th, 2019
+
+- Fix a bug with ``model_pb_to_entity_pb`` method not correctly handling
+  ``null`` values for nested ``google.protobuf.Struct`` fields. #16
+
 # v0.1.5 - August 16th, 2019
 
 - Add support for new ``exclude_from_index`` argument to the

--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -419,6 +419,8 @@ def set_value_pb_item_value(value_pb, value):
         # Custom user-defined type
         entity_pb_item = model_pb_to_entity_pb(value, exclude_falsy_values=True)
         value_pb.entity_value.CopyFrom(entity_pb_item)
+    elif value is None:
+        value_pb.null_value = struct_pb2.NULL_VALUE
     else:
         raise ValueError('Unsupported type for value: %s' % (value))
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -67,13 +67,15 @@ EXAMPLE_DICT_POPULATED = {
     'struct_key': {
         'key1': u'val1',
         'key2': 2,
-        'key3': [1, 2, 3],
+        'key3': [1, 2, 3, None],
         'key4': u'čđć',
         'key5': {
             'dict_key_1': u'1',
             'dict_key_2': 30,
-            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}]
-        }
+            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}, None],
+            'dict_key_4': None,
+        },
+        'key6': None
     },
     'timestamp_key': dt,
     'geo_point_key': GeoPoint(-20.2, +160.5),
@@ -139,13 +141,15 @@ EXAMPLE_PB_POPULATED.timestamp_key.FromDatetime(dt)
 EXAMPLE_PB_POPULATED.struct_key.update({
     'key1': u'val1',
     'key2': 2,
-    'key3': [1, 2, 3],
+    'key3': [1, 2, 3, None],
     'key4': u'čđć',
     'key5': {
         'dict_key_1': u'1',
         'dict_key_2': 30,
-        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}]
-    }
+        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}, None],
+        'dict_key_4': None
+    },
+    'key6': None
 })
 
 geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)


### PR DESCRIPTION
This pull request fixes a bug with ``model_pb_to_entity_pb`` method not correctly handling ``null`` values for ``google.protobuf.Struct`` fields.