### PR TITLE
More exclude from index improvements

### DIFF
--- a/protobuf_cloud_datastore_translator/utils.py
+++ b/protobuf_cloud_datastore_translator/utils.py
@@ -14,15 +14,20 @@
 # limitations under the License.
 
 import importlib
+
 from typing import Type
+from typing import List
 from typing import Tuple
 from types import ModuleType
 
 from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
 
+from protobuf_cloud_datastore_translator.translator import exclude_field_from_index
+
 
 __all__ = [
-    'get_module_and_class_for_model_name'
+    'get_module_and_class_for_model_name',
+    'get_exclude_from_index_fields_for_model'
 ]
 
 
@@ -46,3 +51,22 @@ def get_module_and_class_for_model_name(model_name):
         raise ValueError('Class "%s" not found in module "%s"' % (model_name, module_path))
 
     return module, model_class
+
+
+def get_exclude_from_index_fields_for_model(model_class):
+    # type: (Type[GeneratedProtocolMessageType]) -> List[str]
+    """
+    Return a list of fields which are marked as to be excluded for the provided model class.
+    """
+
+    fields = list(iter(model_class.DESCRIPTOR.fields))
+
+    result = []
+    for field_descriptor in fields:
+        exclude_from_index = exclude_field_from_index(model=model_class,
+                                                      field_descriptor=field_descriptor)
+
+        if exclude_from_index:
+            result.append(field_descriptor.name)
+
+    return result

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -21,6 +21,7 @@ from google.type import latlng_pb2
 from google.cloud.datastore.helpers import GeoPoint
 
 from tests.generated import example_pb2
+from tests.generated import example_with_options_pb2
 
 __all__ = [
     'EXAMPLE_DICT_POPULATED',
@@ -28,6 +29,8 @@ __all__ = [
 
     'EXAMPLE_PB_POPULATED',
     'EXAMPLE_PB_DEFAULT_VALUES',
+
+    'EXAMPLE_PB_WITH_OPTIONS_1',
 
     'EmulatorCreds'
 ]
@@ -169,6 +172,14 @@ EXAMPLE_PB_DEFAULT_VALUES.bool_key = False
 EXAMPLE_PB_DEFAULT_VALUES.bytes_key = b''
 EXAMPLE_PB_DEFAULT_VALUES.null_key = 0
 # pylint: enable=no-member
+
+EXAMPLE_PB_WITH_OPTIONS_1 = example_with_options_pb2.ExampleDBModelWithOptions1()
+EXAMPLE_PB_WITH_OPTIONS_1.string_key_one = 'one'
+EXAMPLE_PB_WITH_OPTIONS_1.string_key_two = 'two'
+EXAMPLE_PB_WITH_OPTIONS_1.string_key_three = 'three'
+EXAMPLE_PB_WITH_OPTIONS_1.string_key_four = 'four'
+EXAMPLE_PB_WITH_OPTIONS_1.int32_field_one = 100000000
+EXAMPLE_PB_WITH_OPTIONS_1.int32_field_two = 200000000
 
 
 class EmulatorCreds(google.auth.credentials.Credentials):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -29,6 +29,7 @@ from protobuf_cloud_datastore_translator import entity_pb_to_model_pb
 from tests.generated import example_pb2
 from tests.mocks import EXAMPLE_PB_POPULATED
 from tests.mocks import EXAMPLE_PB_DEFAULT_VALUES
+from tests.mocks import EXAMPLE_PB_WITH_OPTIONS_1
 
 
 complex_example_pb = EXAMPLE_PB_POPULATED
@@ -54,6 +55,10 @@ def measure_entity_pb_to_model_pb_simple_model():
     return entity_pb_to_model_pb(example_pb2.ExampleDBModel, simple_entity_pb)
 
 
+def measure_model_pb_to_entity_pb_with_exclude_field_from_index_simple_model():
+    return model_pb_to_entity_pb(model_pb=EXAMPLE_PB_WITH_OPTIONS_1)
+
+
 @pytest.mark.benchmark(
     group='model_pb_to_entity_pb',
     disable_gc=True,
@@ -76,6 +81,21 @@ def test_model_pb_to_entity_pb_simple_model(benchmark):
     result = benchmark(measure_model_pb_to_entity_pb_simple_model)
     assert bool(result)
     assert result.properties['int32_key'].integer_value == 0
+
+
+@pytest.mark.benchmark(
+    group='model_pb_to_entity_pb',
+    disable_gc=True,
+    warmup=False
+)
+def test_model_pb_to_entity_pb_with_exclude_field_from_index_simple_model(benchmark):
+    # benchmark something
+    result = benchmark(measure_model_pb_to_entity_pb_with_exclude_field_from_index_simple_model)
+    assert bool(result)
+    assert result.properties['int32_field_one'].integer_value == 100000000
+    assert result.properties['int32_field_one'].exclude_from_indexes is False
+    assert result.properties['int32_field_two'].integer_value == 200000000
+    assert result.properties['int32_field_two'].exclude_from_indexes is True
 
 
 @pytest.mark.benchmark(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,6 +21,7 @@ import mock
 
 from protobuf_cloud_datastore_translator.translator import get_python_module_for_field
 from protobuf_cloud_datastore_translator.utils import get_module_and_class_for_model_name
+from protobuf_cloud_datastore_translator.utils import get_exclude_from_index_fields_for_model
 from tests.generated import example_pb2
 
 
@@ -95,6 +96,24 @@ class UtilsTestCase(unittest.TestCase):
         expected_msg = 'No module named'
         self.assertRaisesRegexp(ImportError, expected_msg,
                                 get_python_module_for_field, field)
+
+    def test_get_exclude_from_index_fields(self):
+        from tests.generated import example_with_options_pb2
+
+        model_class = example_with_options_pb2.ExampleDBModelWithOptions1
+        exclude_fields = get_exclude_from_index_fields_for_model(model_class=model_class)
+
+        self.assertEqual(exclude_fields, ['string_key_one', 'string_key_three', 'int32_field_two'])
+
+        model_class = example_with_options_pb2.ExampleDBModelWithOptions2
+        exclude_fields = get_exclude_from_index_fields_for_model(model_class=model_class)
+
+        self.assertEqual(exclude_fields, ['int32_field_two'])
+
+        model_class = example_with_options_pb2.ExampleDBModelWithOptions3
+        exclude_fields = get_exclude_from_index_fields_for_model(model_class=model_class)
+
+        self.assertEqual(exclude_fields, [])
 
     def _remove_module_from_sys_module(self, module_name):
         if module_name in sys.modules:


### PR DESCRIPTION
This pull request includes some more improvements to the exclude from index functionality.

The only public API change is new ``get_exclude_from_index_fields_for_model`` utility method. This method returns a list of fields for a particular model class or class instance which are marked as to be excluded from index on the actual Protobuf definition.

This comes handy in various testing and other scenarios.