### PR TITLE
Correctly handle empty array values in deeply nested Struct field types

### DIFF
--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -442,11 +442,15 @@ def set_value_pb_item_value(value_pb, value):
     elif isinstance(value, six.binary_type):
         value_pb.blob_value = value
     elif isinstance(value, list):
-        for value in value:
-            value_pb_item = entity_pb2.Value()
-            value_pb_item = set_value_pb_item_value(value_pb=value_pb_item, value=value)
+        if len(value) == 0:
+            array_value = entity_pb2.ArrayValue(values=[])
+            value_pb.array_value.CopyFrom(array_value)
+        else:
+            for value in value:
+                value_pb_item = entity_pb2.Value()
+                value_pb_item = set_value_pb_item_value(value_pb=value_pb_item, value=value)
 
-            value_pb.array_value.values.append(value_pb_item)
+                value_pb.array_value.values.append(value_pb_item)
     elif isinstance(value, struct_pb2.Value):
         item_value = _GetStructValue(value)
         set_value_pb_item_value(value_pb, item_value)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -94,10 +94,18 @@ EXAMPLE_DICT_POPULATED = {
         'key5': {
             'dict_key_1': u'1',
             'dict_key_2': 30,
-            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}, None],
+            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': []}, None],
             'dict_key_4': None,
         },
-        'key6': None
+        'key6': None,
+        'key7': [],
+        'key8': {
+            'a': {
+                'b': {
+                    'c': []
+                }
+            }
+        }
     },
     'timestamp_key': dt,
     'geo_point_key': GeoPoint(-20.2, +160.5),
@@ -191,10 +199,18 @@ EXAMPLE_PB_POPULATED.struct_key.update({
     'key5': {
         'dict_key_1': u'1',
         'dict_key_2': 30,
-        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2]}, None],
+        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': []}, None],
         'dict_key_4': None
     },
-    'key6': None
+    'key6': None,
+    'key7': [],
+    'key8': {
+        'a': {
+            'b': {
+                'c': []
+            }
+        }
+    }
 })
 
 geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -862,6 +862,41 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         model_pb = entity_pb_to_model_pb(example_pb2.ExampleDBModel, entity_pb)
         self.assertEqual(model_pb, example_pb)
 
+    def test_model_pb_to_entity_pb_nested_struct_empty_array(self):
+        struct1_pb = struct_pb2.Struct()
+        struct1_pb.update({
+            'a': {
+                'a': [],
+                'b': {
+                    'c': []
+                }
+            },
+            'b': []
+        })
+
+        example_pb = example_pb2.ExampleDBModel()
+        example_pb.struct_key.CopyFrom(struct1_pb)
+
+        entity_pb = model_pb_to_entity_pb(model_pb=example_pb)
+
+        self.assertEqual(
+            entity_pb.properties['struct_key']
+            .entity_value.properties['a']
+            .entity_value.properties['b']
+            .entity_value.properties['c'].array_value,
+            entity_pb2.ArrayValue(values=[]))
+
+        self.assertEqual(
+            entity_pb.properties['struct_key']
+            .entity_value.properties['b'].array_value,
+            entity_pb2.ArrayValue(values=[]))
+
+        self.assertEqual(
+            entity_pb.properties['struct_key']
+            .entity_value.properties['a']
+            .entity_value.properties['a'].array_value,
+            entity_pb2.ArrayValue(values=[]))
+
     def assertEntityPbHasPopulatedField(self, entity_pb, field_name):
         # type: (entity_pb2.Entity, str) -> None
         """


### PR DESCRIPTION
This pull request fixes ``model_pb_to_entity_pb`` function so we correctly handle empty arrays in nested Struct types.

Previously we didn't correctly set empty array value in such scenario, so trying to store such Entity in the datastore would fail with the following error:

```bash
grpc._channel._Rendezvous: <_Rendezvous of RPC that terminated with:
	status = StatusCode.INVALID_ARGUMENT
	details = "The value "assets" does not contain a value."
	debug_error_string = "{"created":"@1568020805.117237970","description":"Error received from peer","file":"src/core/lib/surface/call.cc","file_line":1099,"grpc_message":"The value "assets" does not contain a value.","grpc_status":3}"
```

Example entity before the change:

```python
properties {
  key: "struct_key"
  value {
    entity_value {
      properties {
        key: "a"
        value {
          entity_value {
            properties {
              key: "b"
              value {
                entity_value {
                  properties {
                    key: "c"
                    value {
                   }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```

And after the change:

```python
properties {
  key: "struct_key"
  value {
    entity_value {
      properties {
        key: "a"
        value {
          entity_value {
            properties {
              key: "b"
              value {
                entity_value {
                  properties {
                    key: "c"
                    value {
                      array_value {
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```