### PR TITLE
Correctly handle boolean values inside Struct fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# v0.1.12 - September 24th, 2019
+
+* Fix a bug with boolean values inside Struct fields not being handled and
+  serialized correctly (they were serialized as integer instead of boolean
+  value). #23
+
+  Reported by @Sheshagiri
+
 # v0.1.11 - September 9th, 2019
 
 * Fix ``model_pb_to_entity_pb`` to correctly handle deeply nested Struct types

--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -435,6 +435,8 @@ def set_value_pb_item_value(value_pb, value):
 
     if isinstance(value, six.text_type):
         value_pb.string_value = value
+    elif isinstance(value, bool):
+        value_pb.boolean_value = value
     elif isinstance(value, int):
         value_pb.integer_value = value
     elif isinstance(value, float):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -94,7 +94,7 @@ EXAMPLE_DICT_POPULATED = {
         'key5': {
             'dict_key_1': u'1',
             'dict_key_2': 30,
-            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'h': True,
+            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'l': True,
                                                  u'm': False}, None],
             'dict_key_4': None,
         },
@@ -202,8 +202,8 @@ EXAMPLE_PB_POPULATED.struct_key.update({
     'key5': {
         'dict_key_1': u'1',
         'dict_key_2': 30,
-        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'h': True,
-                                                u'm': False}, None],
+        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'l': True,
+                                             u'm': False}, None],
         'dict_key_4': None
     },
     'key6': None,

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -89,12 +89,13 @@ EXAMPLE_DICT_POPULATED = {
     'struct_key': {
         'key1': u'val1',
         'key2': 2,
-        'key3': [1, 2, 3, None],
+        'key3': [1, 2, 3, None, True, False],
         'key4': u'čđć',
         'key5': {
             'dict_key_1': u'1',
             'dict_key_2': 30,
-            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': []}, None],
+            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'h': True,
+                                                 u'm': False}, None],
             'dict_key_4': None,
         },
         'key6': None,
@@ -105,7 +106,9 @@ EXAMPLE_DICT_POPULATED = {
                     'c': []
                 }
             }
-        }
+        },
+        'key9': True,
+        'key10': False
     },
     'timestamp_key': dt,
     'geo_point_key': GeoPoint(-20.2, +160.5),
@@ -194,12 +197,13 @@ EXAMPLE_PB_POPULATED.timestamp_key.FromDatetime(dt)
 EXAMPLE_PB_POPULATED.struct_key.update({
     'key1': u'val1',
     'key2': 2,
-    'key3': [1, 2, 3, None],
+    'key3': [1, 2, 3, None, True, False],
     'key4': u'čđć',
     'key5': {
         'dict_key_1': u'1',
         'dict_key_2': 30,
-        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': []}, None],
+        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'h': True,
+                                                u'm': False}, None],
         'dict_key_4': None
     },
     'key6': None,
@@ -210,7 +214,9 @@ EXAMPLE_PB_POPULATED.struct_key.update({
                 'c': []
             }
         }
-    }
+    },
+    'key9': True,
+    'key10': False
 })
 
 geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)
@@ -229,6 +235,7 @@ EXAMPLE_PB_DEFAULT_VALUES.enum_key = example_pb2.ExampleEnumModel.ENUM0
 EXAMPLE_PB_DEFAULT_VALUES.bool_key = False
 EXAMPLE_PB_DEFAULT_VALUES.bytes_key = b''
 EXAMPLE_PB_DEFAULT_VALUES.null_key = 0
+EXAMPLE_PB_DEFAULT_VALUES.struct_key.update({})
 # pylint: enable=no-member
 
 EXAMPLE_PB_WITH_OPTIONS_1 = example_with_options_pb2.ExampleDBModelWithOptions1()

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -115,7 +115,6 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         entity = datastore.Entity()
         entity.update(EXAMPLE_DICT_DEFAULT_VALUES)
 
-
         entity_pb_native = datastore.helpers.entity_to_protobuf(entity)
 
         self.assertEqual(repr(entity_pb_native), repr(entity_pb_translated))

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -115,6 +115,7 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         entity = datastore.Entity()
         entity.update(EXAMPLE_DICT_DEFAULT_VALUES)
 
+
         entity_pb_native = datastore.helpers.entity_to_protobuf(entity)
 
         self.assertEqual(repr(entity_pb_native), repr(entity_pb_translated))
@@ -398,7 +399,8 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
             example_with_package_referenced_type_pb)
 
         example_with_nested_struct_db_model_pb = example_pb2.ExampleWithNestedStructDBModel()
-        example_with_nested_struct_db_model_pb.struct_key.update({'foo': 'bar', 'bar': 'baz'})
+        example_with_nested_struct_db_model_pb.struct_key.update({'foo': 'bar', 'bar': 'baz',
+                                                                  'bool1': True, 'bool2': False})
 
         example_with_referenced_type_pb.referenced_struct_key.CopyFrom(
             example_with_nested_struct_db_model_pb)
@@ -421,6 +423,12 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
         self.assertEqual(entity_pb_translated.properties['referenced_struct_key'].entity_value
                          .properties['struct_key'].entity_value.properties['bar'].string_value,
                          'baz')
+        self.assertEqual(entity_pb_translated.properties['referenced_struct_key'].entity_value
+                         .properties['struct_key'].entity_value.properties['bool1'].boolean_value,
+                         True)
+        self.assertEqual(entity_pb_translated.properties['referenced_struct_key'].entity_value
+                         .properties['struct_key'].entity_value.properties['bool2'].boolean_value,
+                         False)
 
         # Perform the round trip, translate it back to the model and verity it matches the original
         # input


### PR DESCRIPTION
This pull request fixes a bug where translator didn't correctly handle boolean values inside Struct fields.

Those values were incorrectly serialized as an integer_value instead of boolean_value.

Thanks to @Sheshagiri for reporting this issue.