### PR TITLE
Correctly handle numbers inside Struct field types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# v0.1.13 - September 25th, 2019
+
+* Fix a bug so number values are correctly handled inside Struct fields.
+
+  Struct field value mimics JSON types which means that for numbers, it
+  only supports JSON "number" type which is a double. This means we need
+  to correctly handle all the numbers (integers and doubles) inside
+  Structs and cast them to double type. #24
+
 # v0.1.12 - September 24th, 2019
 
 * Fix a bug with boolean values inside Struct fields not being handled and

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Right now the library supports the following Protobuf field types and functional
 * All the simple types (string, int32, int64, double, float, bytes, bool, enum)
 * Scalar / container types (map, repeated)
 * Complex types from Protobuf standard library (``google.protobuf.Timestamp``,
-  ``google.Protobuf.Struct``, ``google.types.LatLng``)
+  ``google.protobuf.Struct``, ``google.types.LatLng``)
 * Using imports and referencing types from different Protobuf definition files. For example,
   you can have Protobuf message definition called ``Model1DB`` inside file ``model1.proto`` which
   has a field which references ``Model2DB`` from ``model2.proto`` file.
@@ -48,7 +48,7 @@ Right now the library supports the following Protobuf field types and functional
 For more information on the actual types supported by Google Datastore, refer to
 https://cloud.google.com/datastore/docs/concepts/entities#properties_and_value_types.
 
-## Supported Python versions:
+## Supported Python versions
 
 * Python 2.7
 * Python 3.6
@@ -247,6 +247,8 @@ message ExampleDBModelWithOptions1 {
 
 ## Gotchas
 
+### Default values
+
 In Protobuf syntax version 3 a concept of field being set has been removed and combined with a
 concept of a default value. This means that even when a field is not set, a default value which
 is specific to that field type will be returned.
@@ -291,6 +293,16 @@ For details, see:
 * https://github.com/googleapis/google-cloud-python/issues/1402
 * https://github.com/googleapis/google-cloud-python/pull/1450
 * https://github.com/googleapis/google-cloud-python/pull/1329
+
+### Struct Field type
+
+This library supports ``google.protobuf.Struct`` field type out of the box. Struct field values
+are serialized as an embedded entity.
+
+Keep in mind that ``google.protobuf.Struct`` field type mimics JSON type which only supports
+``number`` type for numeric values. This means all the numbers (including integers) are
+represented as double precision floating point values (internally on the Entity, that's stored as
+``value_pb.double_value``).
 
 ## Examples
 
@@ -340,14 +352,14 @@ model_pb = entity_pb_to_model_pb(my_model_pb2.MyModelPB, entity_pb)
 print(model_pb)
 ```
 
-### Translator Libraries for Other Programming Languages
+## Translator Libraries for Other Programming Languages
 
 This section contains a list of translator libraries for other programming languages which offer
 the same functionality.
 
 * Golang - [go-protobuf-cloud-datastore-entity-translator](https://github.com/Sheshagiri/go-protobuf-cloud-datastore-entity-translator)
 
-### Tests
+## Tests
 
 Unit and integration tests can be found inside ``tests/`` directory.
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,55 @@ message ExampleDBModelWithOptions1 {
 }
 ```
 
+## Examples
+
+For example Protobuf message definitions, see ``protobuf/`` directory.
+
+Example usage:
+
+```python
+from google.cloud import datastore
+
+from protobuf_cloud_datastore_translator import model_pb_to_entity_pb
+from protobuf_cloud_datastore_translator import entity_pb_to_model_pb
+
+from generated.protobuf.models import my_model_pb2
+
+# 1. Store your database model object which is represented using a custom Protobuf message class
+# instance inside Google Datastore
+
+# Create database model Protobuf instance
+model_pb = my_model_pb2.MyModelDB()
+model_pb.key1 = 'value1'
+model_pb.key2 = 200
+
+# Convert it to Entity Protobuf object which can be used with Google Datastore
+entity_pb = model_pb_to_entity_pb(model_pb)
+
+# Store it in the datastore
+# To avoid conversion back and forth you can also use lower level client methods which
+# work directly with the Entity Protobuf objects
+# For information on the low level client usage, see
+# https://github.com/GoogleCloudPlatform/google-cloud-datastore/blob/master/python/demos/trivial/adams.py#L66
+client = Client(...)
+key = self.client.key('MyModelDB', 'some_primary_key')
+entity_pb_translated.key.CopyFrom(key.to_protobuf())
+
+entity = datastore.helpers.entity_from_protobuf(entity_pb)
+client.put(entity)
+
+# 2. Retrieve entity from the datastore and convert it to your Protobuf DB model instance class
+# Same here - you can also use low level client to retrieve Entity protobuf object directly and
+# avoid unnecessary conversion round trip
+key = client.key('MyModelDB', 'some_primary_key')
+entity = client.get(key)
+entity_pb = datastore.helpers.entity_to_protobuf(entity)
+
+model_pb = entity_pb_to_model_pb(my_model_pb2.MyModelPB, entity_pb)
+print(model_pb)
+```
+
+
 ## Gotchas
 
 ### Default values
@@ -303,54 +352,6 @@ Keep in mind that ``google.protobuf.Struct`` field type mimics JSON type which o
 ``number`` type for numeric values. This means all the numbers (including integers) are
 represented as double precision floating point values (internally on the Entity, that's stored as
 ``value_pb.double_value``).
-
-## Examples
-
-For example Protobuf message definitions, see ``protobuf/`` directory.
-
-Example usage:
-
-```python
-from google.cloud import datastore
-
-from protobuf_cloud_datastore_translator import model_pb_to_entity_pb
-from protobuf_cloud_datastore_translator import entity_pb_to_model_pb
-
-from generated.protobuf.models import my_model_pb2
-
-# 1. Store your database model object which is represented using a custom Protobuf message class
-# instance inside Google Datastore
-
-# Create database model Protobuf instance
-model_pb = my_model_pb2.MyModelDB()
-model_pb.key1 = 'value1'
-model_pb.key2 = 200
-
-# Convert it to Entity Protobuf object which can be used with Google Datastore
-entity_pb = model_pb_to_entity_pb(model_pb)
-
-# Store it in the datastore
-# To avoid conversion back and forth you can also use lower level client methods which
-# work directly with the Entity Protobuf objects
-# For information on the low level client usage, see
-# https://github.com/GoogleCloudPlatform/google-cloud-datastore/blob/master/python/demos/trivial/adams.py#L66
-client = Client(...)
-key = self.client.key('MyModelDB', 'some_primary_key')
-entity_pb_translated.key.CopyFrom(key.to_protobuf())
-
-entity = datastore.helpers.entity_from_protobuf(entity_pb)
-client.put(entity)
-
-# 2. Retrieve entity from the datastore and convert it to your Protobuf DB model instance class
-# Same here - you can also use low level client to retrieve Entity protobuf object directly and
-# avoid unnecessary conversion round trip
-key = client.key('MyModelDB', 'some_primary_key')
-entity = client.get(key)
-entity_pb = datastore.helpers.entity_to_protobuf(entity)
-
-model_pb = entity_pb_to_model_pb(my_model_pb2.MyModelPB, entity_pb)
-print(model_pb)
-```
 
 ## Translator Libraries for Other Programming Languages
 

--- a/README.md
+++ b/README.md
@@ -349,9 +349,9 @@ This library supports ``google.protobuf.Struct`` field type out of the box. Stru
 are serialized as an embedded entity.
 
 Keep in mind that ``google.protobuf.Struct`` field type mimics JSON type which only supports
-``number`` type for numeric values. This means all the numbers (including integers) are
-represented as double precision floating point values (internally on the Entity, that's stored as
-``value_pb.double_value``).
+``number`` type for numeric values (https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto#L62).
+This means all the numbers (including integers) are represented as double precision floating
+point values (internally on the Entity, that's stored as ``value_pb.double_value``).
 
 ## Translator Libraries for Other Programming Languages
 

--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -422,6 +422,10 @@ def set_value_pb_item_value(value_pb, value, is_struct=False):
     Set a value attribute on the Value object based on the type of the provided value.
 
     NOTE: For complex nested types (e.g. dicts and structs this function uses recursion).
+
+    :param is_struct: True if the provided value is part of a struct. This is important because
+                      numbers inside struct field types are handled differently (only double number
+                      types are supported).
     """
     if isinstance(value, struct_pb2.ListValue):
         # Cast special ListValue type to a list

--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -409,15 +409,15 @@ def get_entity_pb_for_value(value):
 
         for key, value in six.iteritems(value):
             value_pb = datastore.helpers._new_value_pb(entity_pb, key)
-            value_pb = set_value_pb_item_value(value_pb=value_pb, value=value)
+            value_pb = set_value_pb_item_value(value_pb=value_pb, value=value, is_struct=True)
     else:
         raise ValueError('Unsupported attribute type: %s' % (attr_type))
 
     return entity_pb
 
 
-def set_value_pb_item_value(value_pb, value):
-    # type: (entity_pb2.Value, Any) -> entity_pb2.Value
+def set_value_pb_item_value(value_pb, value, is_struct=False):
+    # type: (entity_pb2.Value, Any, bool) -> entity_pb2.Value
     """
     Set a value attribute on the Value object based on the type of the provided value.
 
@@ -428,8 +428,10 @@ def set_value_pb_item_value(value_pb, value):
         value = cast(Any, value)
         value = list(value)
 
-    if isinstance(value, float) and value.is_integer():
+    if isinstance(value, float) and value.is_integer() and not is_struct:
         # Special case because of how Protobuf handles ints in some scenarios (e.g. Struct)
+        # Regular Entity value supports integeres and double number types, but Struct mimics
+        # JSON so it only supports "number" type which is always a double
         value = cast(Any, value)
         value = int(value)
 
@@ -450,12 +452,12 @@ def set_value_pb_item_value(value_pb, value):
         else:
             for value in value:
                 value_pb_item = entity_pb2.Value()
-                value_pb_item = set_value_pb_item_value(value_pb=value_pb_item, value=value)
+                value_pb_item = set_value_pb_item_value(value_pb=value_pb_item, value=value, is_struct=is_struct)
 
                 value_pb.array_value.values.append(value_pb_item)
     elif isinstance(value, struct_pb2.Value):
         item_value = _GetStructValue(value)
-        set_value_pb_item_value(value_pb, item_value)
+        set_value_pb_item_value(value_pb, item_value, is_struct=is_struct)
     elif hasattr(value, 'DESCRIPTOR'):
         # Custom user-defined type
         entity_pb_item = model_pb_to_entity_pb(value, exclude_falsy_values=True)

--- a/protobuf_cloud_datastore_translator/translator.py
+++ b/protobuf_cloud_datastore_translator/translator.py
@@ -452,7 +452,8 @@ def set_value_pb_item_value(value_pb, value, is_struct=False):
         else:
             for value in value:
                 value_pb_item = entity_pb2.Value()
-                value_pb_item = set_value_pb_item_value(value_pb=value_pb_item, value=value, is_struct=is_struct)
+                value_pb_item = set_value_pb_item_value(value_pb=value_pb_item, value=value,
+                                                        is_struct=is_struct)
 
                 value_pb.array_value.values.append(value_pb_item)
     elif isinstance(value, struct_pb2.Value):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -89,14 +89,15 @@ EXAMPLE_DICT_POPULATED = {
     'struct_key': {
         'key1': u'val1',
         'key2': 2,
-        'key3': [1, 2, 3, None, True, False],
+        'key3': [1, 2, 3, 4.44, None, True, False],
         'key4': u'čđć',
         'key5': {
             'dict_key_1': u'1',
             'dict_key_2': 30,
-            'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'l': True,
-                                                 u'm': False}, None],
+            'dict_key_3': [u'a', u'b', u'c', 7, {u'h': u'bar', u'g': [1, 2, 33.33], u'j': [],
+                                                 u'l': True, u'm': False}, None],
             'dict_key_4': None,
+            'dict_key_5': 55.55
         },
         'key6': None,
         'key7': [],
@@ -108,7 +109,8 @@ EXAMPLE_DICT_POPULATED = {
             }
         },
         'key9': True,
-        'key10': False
+        'key10': False,
+        'key11': 11.123
     },
     'timestamp_key': dt,
     'geo_point_key': GeoPoint(-20.2, +160.5),
@@ -197,14 +199,15 @@ EXAMPLE_PB_POPULATED.timestamp_key.FromDatetime(dt)
 EXAMPLE_PB_POPULATED.struct_key.update({
     'key1': u'val1',
     'key2': 2,
-    'key3': [1, 2, 3, None, True, False],
+    'key3': [1, 2, 3, 4.44, None, True, False],
     'key4': u'čđć',
     'key5': {
         'dict_key_1': u'1',
         'dict_key_2': 30,
-        'dict_key_3': [u'a', u'b', u'c', 3, {u'h': u'bar', u'g': [1, 2], u'j': [], u'l': True,
+        'dict_key_3': [u'a', u'b', u'c', 7, {u'h': u'bar', u'g': [1, 2, 33.33], u'j': [], u'l': True,
                                              u'm': False}, None],
-        'dict_key_4': None
+        'dict_key_4': None,
+        'dict_key_5': 55.55
     },
     'key6': None,
     'key7': [],
@@ -216,7 +219,8 @@ EXAMPLE_PB_POPULATED.struct_key.update({
         }
     },
     'key9': True,
-    'key10': False
+    'key10': False,
+    'key11': 11.123
 })
 
 geo_point_value = latlng_pb2.LatLng(latitude=-20.2, longitude=+160.5)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -204,8 +204,8 @@ EXAMPLE_PB_POPULATED.struct_key.update({
     'key5': {
         'dict_key_1': u'1',
         'dict_key_2': 30,
-        'dict_key_3': [u'a', u'b', u'c', 7, {u'h': u'bar', u'g': [1, 2, 33.33], u'j': [], u'l': True,
-                                             u'm': False}, None],
+        'dict_key_3': [u'a', u'b', u'c', 7, {u'h': u'bar', u'g': [1, 2, 33.33], u'j': [],
+                                             u'l': True, u'm': False}, None],
         'dict_key_4': None,
         'dict_key_5': 55.55
     },

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -1005,7 +1005,8 @@ class ModelPbToEntityPbTranslatorTestCase(unittest.TestCase):
     def _int_to_double(self, value):
         """
         Function which converts any int value type to double to work around issue with
-        "entity_to_protobuf" function not correctly handling number types inside structs.
+        "entity_to_protobuf" function which handles all the nested values as embedded entities and
+        not structs which only support double type.
         """
         if isinstance(value, list):
             value = [self._int_to_double(item) for item in value]


### PR DESCRIPTION
This pull request updates the translator to correctly handle numbers inside Struct field types.

Regular Datastore Entity values support both integer and double number types (https://github.com/googleapis/googleapis/blob/master/google/datastore/v1beta3/entity.proto#L124), but that's not the case for Struct field types.

Struct mimics JSON which only supports "number" type which is a double. The same is true for Structs (https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto#L62) - it only supports double number types so all the integers need to be cast / handled as doubles.